### PR TITLE
please.sh prerelease: offer to use another branch than `master`

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -518,13 +518,15 @@ require_clean_worktree () {
 }
 
 ff_master () {
-	test refs/heads/master = "$(git rev-parse --symbolic-full-name HEAD)" ||
-	die "%s: Not on 'master'\n" "$sdk/$pkgpath"
+	USE_AS_MASTERBRANCH=${USE_AS_MASTERBRANCH:-master}
+	test refs/heads/"$USE_AS_MASTERBRANCH" = \
+		"$(git rev-parse --symbolic-full-name HEAD)" ||
+	die "%s: Not on '%s'\n" "$sdk/$pkgpath" "$USE_AS_MASTERBRANCH"
 
 	require_clean_worktree
 
-	git pull --ff-only origin master ||
-	die "%s: cannot fast-forward 'master'\n" "$sdk/$pkgpath"
+	git pull --ff-only origin "$USE_AS_MASTERBRANCH" ||
+	die "%s: cannot fast-forward '%s'\n" "$sdk/$pkgpath" "$USE_AS_MASTERBRANCH"
 }
 
 update () { # <package>
@@ -679,11 +681,12 @@ pkg_build () {
 }
 
 fast_forward () {
+	USE_AS_MASTERBRANCH="${USE_AS_MASTERBRANCH:-master}"
 	if test -d "$2"/.git
 	then
-		git -C "$1" fetch "$2" refs/heads/master
+		git -C "$1" fetch "$2" refs/heads/"$USE_AS_MASTERBRANCH"
 	else
-		git -C "$1" fetch "$2"/.. refs/heads/master
+		git -C "$1" fetch "$2"/.. refs/heads/"$USE_AS_MASTERBRANCH"
 	fi &&
 	git -C "$1" merge --ff-only "$3" &&
 	test "a$3" = "a$(git -C "$1" rev-parse --verify HEAD)"
@@ -906,6 +909,7 @@ require_git_src_dir () {
 	then
 		if test ! -d "${git_src_dir%/src/git}"
 		then
+			b=${USE_AS_MASTERBRANCH:-master}
 			mingw_packages_dir="${git_src_dir%/*/src/git}"
 			if test ! -d "$mingw_packages_dir"
 			then
@@ -913,7 +917,9 @@ require_git_src_dir () {
 				*/MINGW-packages)
 					o=https://github.com/git-for-windows &&
 					git -C "${mingw_packages_dir%/*}" \
-						clone $o/MINGW-packages ||
+						clone \
+						--branch "$b" --single-branch \
+						$o/MINGW-packages ||
 					die "Could not clone into %s\n" \
 						"$mingw_packages_dir"
 					;;
@@ -925,7 +931,7 @@ require_git_src_dir () {
 			else
 				git -C "$mingw_packages_dir" fetch &&
 				git -C "$mingw_packages_dir" \
-					checkout -t origin/master ||
+					checkout -t origin/"$b" ||
 				die "Could not check out %s\n" \
 					"$mingw_packages_dir"
 			fi
@@ -1525,6 +1531,9 @@ prerelease () { # [--installer | --portable | --mingit | --mingit-busybox] [--on
 		;;
 	--include-pdbs)
 		include_pdbs=--include-pdbs
+		;;
+	--use-as-master-branch=*)
+		USE_AS_MASTERBRANCH="${1#*=}"
 		;;
 	-*) die "Unknown option: %s\n" "$1";;
 	*) break;;


### PR DESCRIPTION
For the MinGit backport releases, we will want to use a sort of "time
travel": we will use specific branches in the Git for Windows SDKs, in
build-extra and in MINGW-packages.

For simplicity's sake, we will use the same branch name in all four
repositories, e.g. mingit-2.14.x-releases for the v2.14.* release train.

This commit allows us to call

	/usr/src/build-extra/please.sh prerelease \
		--use-as-master-branch=mingit-2.14.x-releases \
		--only-mingit --no-upload --worktree=. HEAD

to use that MINGW-packages branch while building the mingw-w64-git
packages.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
